### PR TITLE
spec(v3.1): \uXXXX escape, key: [] encoding, §15 smuggling note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the TOON specification will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1] - YYYY-MM-DD
+
+### Added
+
+- `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and arbitrary code points (§7.1).
+
 ## [3.0] - 2025-11-24
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,17 @@ All notable changes to the TOON specification will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1] - YYYY-MM-DD
+## [3.1] - 2026-05-18
 
 ### Added
 
-- `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and arbitrary code points (§7.1).
+- `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and BMP code points (§7.1).
 - Security note on control-character round-tripping and downstream sanitization responsibility (§15).
 
 ### Changed
 
 - Empty object-field arrays SHOULD now encode as `key: []` (§9.1). Decoders MUST accept both `key: []` and the legacy `key[0]:` form. Inner empty arrays in arrays-of-arrays (§9.2) retain `- [0]:`.
+- Encoders MUST now emit `\uXXXX` for control characters U+0000–U+001F outside `\n`, `\r`, `\t` (§7.1). v3.0 had no defined escape for these characters; this release formalizes previously undefined behavior without invalidating any prior conformant output.
 
 ## [3.0] - 2025-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and BMP code points (§7.1).
-- Security note on control-character round-tripping (§15).
+- `\uXXXX` Unicode escape in quoted strings and keys; encoders MUST emit it for control characters U+0000–U+001F outside `\n`, `\r`, `\t` (§7.1).
+- Encoders MUST NOT strip control characters from quoted strings during normalization (§15).
 
 ### Changed
 
 - Empty object-field arrays SHOULD now encode as `key: []` (§9.1). Decoders MUST accept both `key: []` and the legacy `key[0]:` form.
-- Encoders MUST emit `\uXXXX` for control characters U+0000–U+001F outside `\n`, `\r`, `\t` (§7.1).
 
 ## [3.0] - 2025-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and BMP code points (§7.1).
-- Security note on control-character round-tripping and downstream sanitization responsibility (§15).
+- Security note on control-character round-tripping (§15).
 
 ### Changed
 
-- Empty object-field arrays SHOULD now encode as `key: []` (§9.1). Decoders MUST accept both `key: []` and the legacy `key[0]:` form. Inner empty arrays in arrays-of-arrays (§9.2) retain `- [0]:`.
-- Encoders MUST now emit `\uXXXX` for control characters U+0000–U+001F outside `\n`, `\r`, `\t` (§7.1). v3.0 had no defined escape for these characters; this release formalizes previously undefined behavior without invalidating any prior conformant output.
+- Empty object-field arrays SHOULD now encode as `key: []` (§9.1). Decoders MUST accept both `key: []` and the legacy `key[0]:` form.
+- Encoders MUST emit `\uXXXX` for control characters U+0000–U+001F outside `\n`, `\r`, `\t` (§7.1).
 
 ## [3.0] - 2025-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and arbitrary code points (§7.1).
+- Security note on control-character round-tripping and downstream sanitization responsibility (§15).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `\uXXXX` Unicode escape in quoted strings and keys for representing control characters and arbitrary code points (§7.1).
 
+### Changed
+
+- Empty object-field arrays SHOULD now encode as `key: []` (§9.1). Decoders MUST accept both `key: []` and the legacy `key[0]:` form. Inner empty arrays in arrays-of-arrays (§9.2) retain `- [0]:`.
+
 ## [3.0] - 2025-11-24
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TOON Format Specification
 
-[![SPEC v3.0](https://img.shields.io/badge/spec-v3.0-lightgrey)](./SPEC.md)
-[![Tests](https://img.shields.io/badge/tests-358-green)](./tests/fixtures/)
+[![SPEC v3.1](https://img.shields.io/badge/spec-v3.1-lightgrey)](./SPEC.md)
+[![Tests](https://img.shields.io/badge/tests-368-green)](./tests/fixtures/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 This repository contains the official specification for **Token-Oriented Object Notation (TOON)**, a compact, human-readable encoding of the JSON data model for LLM prompts. It provides a lossless serialization of the same objects, arrays, and primitives as JSON, but in a syntax that minimizes tokens and makes structure easy for models to follow.
@@ -10,7 +10,7 @@ This repository contains the official specification for **Token-Oriented Object 
 
 [→ Read the full specification (SPEC.md)](./SPEC.md)
 
-- **Version:** 3.0 (2025-11-24)
+- **Version:** 3.1 (YYYY-MM-DD)
 - **Status:** Working Draft
 - **License:** MIT
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # TOON Format Specification
 
 [![SPEC v3.1](https://img.shields.io/badge/spec-v3.1-lightgrey)](./SPEC.md)
-[![Tests](https://img.shields.io/badge/tests-368-green)](./tests/fixtures/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 This repository contains the official specification for **Token-Oriented Object Notation (TOON)**, a compact, human-readable encoding of the JSON data model for LLM prompts. It provides a lossless serialization of the same objects, arrays, and primitives as JSON, but in a syntax that minimizes tokens and makes structure easy for models to follow.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the official specification for **Token-Oriented Object 
 
 [→ Read the full specification (SPEC.md)](./SPEC.md)
 
-- **Version:** 3.1 (YYYY-MM-DD)
+- **Version:** 3.1 (2026-05-18)
 - **Status:** Working Draft
 - **License:** MIT
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -246,7 +246,7 @@ See Appendix G for non-normative language-specific examples (Go, JavaScript, Pyt
 Decoders map text tokens to host values:
 
 - Quoted tokens (strings and keys):
-  - MUST be unescaped per Section 7.1 (only \\, \", \n, \r, \t, and \uXXXX are valid; see §7.1). Any other escape or an unterminated string MUST error.
+  - MUST be unescaped per Section 7.1. Any other escape or an unterminated string MUST error.
   - Quoted primitives remain strings even if they look like numbers/booleans/null.
 - Unquoted value tokens:
   - true, false, null → booleans/null.
@@ -443,7 +443,7 @@ Decoding of value tokens follows §4 (unquoted type inference, quoted strings, n
 
 - Encoding:
   - Non-empty arrays: `key[N<delim?>]: v1<delim>v2<delim>…` where each vi is encoded as a primitive (Section 7) with delimiter-aware quoting.
-  - Empty arrays (object field position): encoders SHOULD emit `key: []` (a key followed by the two-character literal `[]`). Encoders MAY emit the legacy header form `key[0<delim?>]:` for backward compatibility.
+  - Empty arrays (object field position): encoders SHOULD emit `key: []`. Encoders MAY emit the legacy header form `key[0<delim?>]:` for backward compatibility.
   - Empty arrays (root position): encoders SHOULD emit `[]` on its own line. Encoders MAY emit the legacy `[0<delim?>]:` form.
   - Root arrays: `[N<delim?>]: v1<delim>…`
 - Decoding:
@@ -459,7 +459,7 @@ Decoding of value tokens follows §4 (unquoted type inference, quoted strings, n
   - Each inner primitive array is a list item:
     - `- [M<delim?>]: v1<delim>v2<delim>…`
     - Empty inner arrays: `- [0<delim?>]:`
-    - Inner empty arrays in this form retain `- [0<delim?>]:` for parse clarity; the `key: []` field-level form (§9.1) does NOT apply to list-item inner arrays.
+    - The `key: []` field-level form (§9.1) does NOT apply to list-item inner arrays.
 - Decoding:
   - Items appear at depth +1, each starting with "- " and an inner array header `[M<delim?>]: …`.
   - Inner arrays are split using their own active delimiter; in strict mode, counts MUST match M.
@@ -524,7 +524,6 @@ For an object appearing as a list item:
     - All other fields of the same object MUST appear at depth +1 under the hyphen line, in encounter order, using normal object field rules (Section 8).
     - Encoders MUST NOT emit tabular rows at depth +1 or sibling fields at the same depth as rows when the first field is a tabular array.
   - For all other cases (first field is not a tabular array), encoders SHOULD place the first field on the hyphen line. A bare hyphen on its own line is used only for empty list-item objects.
-  - Empty arrays in field positions (including list-item object fields) use the canonical `key: []` form per §9.1.
 - Decoding (normative):
   - When a decoder encounters a list-item line of the form `- key[N<delim?>]{fields}:` at depth d, it MUST treat this as the start of a tabular array field named key in the list-item object.
   - Lines at depth d+2 that conform to tabular row syntax (Section 9.3) are rows of that tabular array.
@@ -733,7 +732,6 @@ Validators SHOULD verify:
 - [ ] Whitespace invariants (no trailing spaces/newlines)
 - [ ] Delimiter consistency between headers and rows
 - [ ] Array length counts match declared [N]
-- [ ] Legacy `key[0]:` empty-array emission MAY be flagged as a style diagnostic (§9.1)
 - [ ] All strict-mode requirements (§14)
 
 ## 14. Strict Mode Errors and Diagnostics (Authoritative Checklist)
@@ -801,7 +799,7 @@ Recommended error messages:
   - Strings with colon, the relevant delimiter (document or active), hyphen marker cases ("-" or strings starting with "-"), control characters, or brackets/braces MUST be quoted.
 - Strict-mode checks (Section 14) detect malformed strings, truncation, or injected rows/items via length and width mismatches.
 - Encoders SHOULD avoid excessive memory on large inputs; implement streaming/tabular row emission where feasible.
-- Control characters in quoted strings (`\uXXXX`, §7.1) are preserved as data values; encoders MUST NOT strip them during normalization. Recipients that render decoded values into terminals, logs, or markup are responsible for downstream escaping; TOON is a transport format, not a sanitization boundary.
+- Control characters in quoted strings (`\uXXXX`, §7.1) are preserved as data values; encoders MUST NOT strip them during normalization.
 - Unicode:
   - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with the escape repertoire defined in §7.1).
 
@@ -1261,7 +1259,7 @@ This appendix summarizes major changes between spec versions. For the complete c
 
 - Added `\uXXXX` Unicode escape (§7.1) for control characters and BMP code points in quoted strings and keys.
 - Canonical encoding of empty object-field arrays as `key: []` (§9.1); legacy `key[0]:` remains accepted by decoders.
-- Added security note on control-character round-tripping and downstream sanitization responsibility (§15).
+- Added security note on control-character round-tripping (§15).
 
 ### v3.0 (2025-11-24)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -702,7 +702,8 @@ Conforming encoders MUST:
 - [ ] Use consistent indentation (default 2 spaces, no tabs) (§12)
 - [ ] Escape per §7.1 in quoted strings; reject other escapes
 - [ ] Quote strings containing active delimiter, colon, or structural characters (§7.2)
-- [ ] Emit array lengths [N] matching actual item count (§6, §9); empty object-field arrays SHOULD use `key: []` (§9.1)
+- [ ] Emit array lengths [N] matching actual item count (§6, §9)
+- [ ] Prefer `key: []` for empty object-field arrays (§9.1)
 - [ ] Preserve object key order as encountered (§2)
 - [ ] Normalize numbers to non-exponential decimal form (§2)
 - [ ] Convert -0 to 0 (§2)

--- a/SPEC.md
+++ b/SPEC.md
@@ -246,7 +246,7 @@ See Appendix G for non-normative language-specific examples (Go, JavaScript, Pyt
 Decoders map text tokens to host values:
 
 - Quoted tokens (strings and keys):
-  - MUST be unescaped per Section 7.1 (only \\, \", \n, \r, \t are valid). Any other escape or an unterminated string MUST error.
+  - MUST be unescaped per Section 7.1 (only \\, \", \n, \r, \t, and \uXXXX are valid; see §7.1). Any other escape or an unterminated string MUST error.
   - Quoted primitives remain strings even if they look like numbers/booleans/null.
 - Unquoted value tokens:
   - true, false, null → booleans/null.
@@ -370,7 +370,19 @@ In quoted strings and keys, the following characters MUST be escaped:
 - U+000D carriage return → "\\r"
 - U+0009 tab → "\\t"
 
-Decoders MUST reject any other escape sequence and unterminated strings.
+Control characters in the range U+0000 through U+001F that are not U+000A, U+000D, or U+0009 MUST be encoded using the `\uXXXX` form, where `XXXX` is exactly four hexadecimal digits. Encoders SHOULD emit lowercase hexadecimal digits. Encoders MAY use `\uXXXX` for any other Unicode code point but SHOULD prefer literal UTF-8 for printable characters.
+
+Decoders MUST accept `\uXXXX` (case-insensitive hex digits) in quoted strings and quoted keys, converting the four digits to the corresponding Unicode code point. Decoders MUST reject `\u` followed by fewer than four hex digits, MUST reject lone surrogate code points U+D800–U+DFFF decoded from `\uXXXX`, and MUST reject any other escape sequence or unterminated strings.
+
+Supplementary code points (> U+FFFF) are represented as literal UTF-8 in quoted strings; surrogate-pair sequences (two consecutive `\uXXXX` escapes) are not recognized.
+
+Normative escape grammar:
+
+```abnf
+HEXDIG         = DIGIT / %x41-46 / %x61-66
+escaped-char   = "\" ( "\" / DQUOTE / "n" / "r" / "t" / unicode-escape )
+unicode-escape = %x75 4HEXDIG
+```
 
 Tabs are allowed inside quoted strings and as a declared delimiter; they MUST NOT be used for indentation (Section 12).
 
@@ -682,7 +694,7 @@ Examples:
 Conforming encoders MUST:
 - [ ] Produce UTF-8 output with LF (U+000A) line endings (§5)
 - [ ] Use consistent indentation (default 2 spaces, no tabs) (§12)
-- [ ] Escape \\, ", \n, \r, \t in quoted strings; reject other escapes (§7.1)
+- [ ] Escape per §7.1 in quoted strings; reject other escapes
 - [ ] Quote strings containing active delimiter, colon, or structural characters (§7.2)
 - [ ] Emit array lengths [N] matching actual item count (§6, §9)
 - [ ] Preserve object key order as encountered (§2)
@@ -698,7 +710,7 @@ Conforming encoders MUST:
 Conforming decoders MUST:
 - [ ] Parse array headers per §6 (length, delimiter, optional fields)
 - [ ] Split inline arrays and tabular rows using active delimiter only (§11)
-- [ ] Unescape quoted strings with only valid escapes (§7.1)
+- [ ] Unescape per §7.1
 - [ ] Type unquoted primitives: true/false/null → booleans/null, numeric → number, else → string (§4)
 - [ ] Enforce strict-mode rules when `strict=true` (§14)
 - [ ] Preserve array order and object key order (§2)
@@ -780,7 +792,7 @@ Recommended error messages:
 - Strict-mode checks (Section 14) detect malformed strings, truncation, or injected rows/items via length and width mismatches.
 - Encoders SHOULD avoid excessive memory on large inputs; implement streaming/tabular row emission where feasible.
 - Unicode:
-  - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with only the five escapes).
+  - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with the escape repertoire defined in §7.1).
 
 ## 16. Internationalization
 
@@ -1175,7 +1187,7 @@ These sketches illustrate structure and common decoding helpers. They are inform
 
 ### B.4 Primitive Token Parsing
 
-- If token starts with a quote, it MUST be a properly quoted string (no trailing characters after the closing quote). Unescape using only the five escapes; otherwise MUST error.
+- If token starts with a quote, it MUST be a properly quoted string (no trailing characters after the closing quote). Unescape per §7.1; otherwise MUST error.
 - Else if token is true/false/null → boolean/null.
 - Else if token is numeric without forbidden leading zeros and finite → number.
   - Examples: `"1.5000"` → `1.5`, `"-1E+03"` → `-1000`, `"-0"` → `0` (host normalization applies)
@@ -1232,6 +1244,10 @@ Note: Host-type normalization tests (e.g., BigInt, Date, Set, Map) are language-
 ## Appendix D: Document Changelog (Informative)
 
 This appendix summarizes major changes between spec versions. For the complete changelog, see [`CHANGELOG.md`](./CHANGELOG.md) in the specification repository.
+
+### v3.1 (YYYY-MM-DD)
+
+- Added `\uXXXX` Unicode escape (§7.1) for control characters and arbitrary code points in quoted strings and keys.
 
 ### v3.0 (2025-11-24)
 
@@ -1410,7 +1426,7 @@ This profile captures the most common, memory-friendly rules by reference to nor
 - Indentation: MUST conform to §12 (2 spaces per level by default; strict mode enforces indentSize multiples).
 - Keys and colon syntax: MUST conform to §7.2 (unquoted keys match ^[A-Za-z_][A-Za-z0-9_.]*$; quoted otherwise; colon required after keys).
 - Strings and quoting: MUST be quoted as defined in §7.2 (deterministic quoting rules for empty strings, whitespace, reserved literals, control characters, delimiters, leading hyphens, and structural tokens).
-- Escape sequences: MUST conform to §7.1 (only \\, \", \n, \r, \t are valid).
+- Escape sequences: MUST conform to §7.1.
 - Numbers: Encoders MUST emit canonical form per §2; decoders MUST accept input per §4.
 - Arrays and headers: Header syntax MUST conform to §6; array encoding as defined in §9.
 - Delimiters: Delimiter scoping and quoting rules as defined in §11.
@@ -1429,7 +1445,7 @@ For a detailed version history, see Appendix D.
 - Backward-compatible evolutions SHOULD preserve current headers, quoting rules, and indentation semantics.
 - Reserved/structural characters (colon, brackets, braces, hyphen) MUST retain current meanings.
 - The path separator (see §1.9) is fixed to `"."` in v1.5; future versions MAY make this configurable.
-- Future work (non-normative): schemas, comments/annotations, additional delimiter profiles, optional \uXXXX escapes (if added, must be precisely defined).
+- Future work (non-normative): schemas, comments/annotations, additional delimiter profiles.
 
 ## 21. Intellectual Property Considerations
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -258,6 +258,7 @@ Decoders map text tokens to host values:
       - `"1.5000"` → numeric value `1.5` (trailing zeros in fractional part are accepted)
       - `"-1E+03"` → numeric value `-1000` (exponent forms are accepted)
       - `"-0"` → numeric value `0` (negative zero decodes to zero; most host environments do not distinguish -0 from 0)
+  - The literal token `[]` in object field position (`key: []`) and root position (`[]`) decodes as an empty array (§9.1).
   - Otherwise → string.
 - Keys:
   - Decoded as strings (quoted keys MUST be unescaped per Section 7.1).
@@ -432,6 +433,7 @@ Decoding of value tokens follows §4 (unquoted type inference, quoted strings, n
 - Dotted keys (e.g., `user.name`) are valid literal keys in TOON. Decoders MUST treat them as single literal keys unless path expansion is explicitly enabled (see §13.4). This preserves backward compatibility and allows safe opt-in expansion behavior.
 - Decoding:
   - A line "key:" with nothing after the colon at depth d opens an object; subsequent lines at depth > d belong to that object until the depth decreases to ≤ d.
+  - A bare `key:` (no value after the colon) MUST decode as an empty or nested object, NOT an empty array. Empty arrays use the explicit `key: []` form (§9.1).
   - Lines "key: value" at the same depth are sibling fields.
 
 ## 9. Arrays
@@ -440,12 +442,14 @@ Decoding of value tokens follows §4 (unquoted type inference, quoted strings, n
 
 - Encoding:
   - Non-empty arrays: `key[N<delim?>]: v1<delim>v2<delim>…` where each vi is encoded as a primitive (Section 7) with delimiter-aware quoting.
-  - Empty arrays: `key[0<delim?>]:` (no values following).
+  - Empty arrays (object field position): encoders SHOULD emit `key: []` (a key followed by the two-character literal `[]`). Encoders MAY emit the legacy header form `key[0<delim?>]:` for backward compatibility.
+  - Empty arrays (root position): encoders SHOULD emit `[]` on its own line. Encoders MAY emit the legacy `[0<delim?>]:` form.
   - Root arrays: `[N<delim?>]: v1<delim>…`
 - Decoding:
   - Split using the active delimiter declared by the header; non-active delimiters MUST NOT split values.
   - When splitting inline arrays, empty tokens (including those surrounded by whitespace) decode to the empty string.
   - In strict mode, the number of decoded values MUST equal N; otherwise MUST error.
+  - Empty arrays: decoders MUST accept `key: []`, `[]`, and the legacy forms `key[0<delim?>]:` and `[0<delim?>]:` as empty arrays.
 
 ### 9.2 Arrays of Arrays (Primitives Only) — Expanded List
 
@@ -454,6 +458,7 @@ Decoding of value tokens follows §4 (unquoted type inference, quoted strings, n
   - Each inner primitive array is a list item:
     - `- [M<delim?>]: v1<delim>v2<delim>…`
     - Empty inner arrays: `- [0<delim?>]:`
+    - Inner empty arrays in this form retain `- [0<delim?>]:` for parse clarity; the `key: []` field-level form (§9.1) does NOT apply to list-item inner arrays.
 - Decoding:
   - Items appear at depth +1, each starting with "- " and an inner array header `[M<delim?>]: …`.
   - Inner arrays are split using their own active delimiter; in strict mode, counts MUST match M.
@@ -696,7 +701,7 @@ Conforming encoders MUST:
 - [ ] Use consistent indentation (default 2 spaces, no tabs) (§12)
 - [ ] Escape per §7.1 in quoted strings; reject other escapes
 - [ ] Quote strings containing active delimiter, colon, or structural characters (§7.2)
-- [ ] Emit array lengths [N] matching actual item count (§6, §9)
+- [ ] Emit array lengths [N] matching actual item count (§6, §9); empty object-field arrays SHOULD use `key: []` (§9.1)
 - [ ] Preserve object key order as encountered (§2)
 - [ ] Normalize numbers to non-exponential decimal form (§2)
 - [ ] Convert -0 to 0 (§2)
@@ -709,6 +714,7 @@ Conforming encoders MUST:
 
 Conforming decoders MUST:
 - [ ] Parse array headers per §6 (length, delimiter, optional fields)
+- [ ] Accept empty arrays in both forms: `key: []` / `[]` and legacy `key[0]:` / `[0]:` (§9.1)
 - [ ] Split inline arrays and tabular rows using active delimiter only (§11)
 - [ ] Unescape per §7.1
 - [ ] Type unquoted primitives: true/false/null → booleans/null, numeric → number, else → string (§4)
@@ -725,6 +731,7 @@ Validators SHOULD verify:
 - [ ] Whitespace invariants (no trailing spaces/newlines)
 - [ ] Delimiter consistency between headers and rows
 - [ ] Array length counts match declared [N]
+- [ ] Legacy `key[0]:` empty-array emission MAY be flagged as a style diagnostic (§9.1)
 - [ ] All strict-mode requirements (§14)
 
 ## 14. Strict Mode Errors and Diagnostics (Authoritative Checklist)
@@ -737,6 +744,7 @@ When strict mode is enabled (default), decoders MUST error on the following cond
 - List arrays: number of list items ≠ declared N.
 - Tabular arrays: number of rows ≠ declared N.
 - Tabular row width mismatches: any row's value count ≠ field count.
+- The count checks above apply only when an explicit `[N]` length is declared. The `key: []` form has no declared length; the count check is N/A (§9.1).
 
 ### 14.2 Syntax Errors
 
@@ -1055,7 +1063,7 @@ Edge cases:
 ```
 name: ""
 
-tags[0]:
+tags: []
 
 version: "123"
 enabled: "true"
@@ -1248,6 +1256,7 @@ This appendix summarizes major changes between spec versions. For the complete c
 ### v3.1 (YYYY-MM-DD)
 
 - Added `\uXXXX` Unicode escape (§7.1) for control characters and arbitrary code points in quoted strings and keys.
+- Canonical encoding of empty object-field arrays as `key: []` (§9.1); legacy `key[0]:` remains accepted by decoders.
 
 ### v3.0 (2025-11-24)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -799,6 +799,7 @@ Recommended error messages:
   - Strings with colon, the relevant delimiter (document or active), hyphen marker cases ("-" or strings starting with "-"), control characters, or brackets/braces MUST be quoted.
 - Strict-mode checks (Section 14) detect malformed strings, truncation, or injected rows/items via length and width mismatches.
 - Encoders SHOULD avoid excessive memory on large inputs; implement streaming/tabular row emission where feasible.
+- Control characters in quoted strings (`\uXXXX`, §7.1) round-trip verbatim per §17.1; encoders MUST NOT strip them during normalization. Recipients that render decoded values into terminals, logs, or markup are responsible for downstream escaping; TOON is a transport format, not a sanitization boundary.
 - Unicode:
   - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with the escape repertoire defined in §7.1).
 
@@ -1257,6 +1258,7 @@ This appendix summarizes major changes between spec versions. For the complete c
 
 - Added `\uXXXX` Unicode escape (§7.1) for control characters and arbitrary code points in quoted strings and keys.
 - Canonical encoding of empty object-field arrays as `key: []` (§9.1); legacy `key[0]:` remains accepted by decoders.
+- Added security note on control-character round-tripping and downstream sanitization responsibility (§15).
 
 ### v3.0 (2025-11-24)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4,7 +4,7 @@
 
 **Version:** 3.1
 
-**Date:** YYYY-MM-DD
+**Date:** 2026-05-18
 
 **Status:** Working Draft
 
@@ -382,7 +382,7 @@ Normative escape grammar:
 
 ```abnf
 HEXDIG         = DIGIT / %x41-46 / %x61-66
-escaped-char   = "\" ( "\" / DQUOTE / "n" / "r" / "t" / unicode-escape )
+escaped-char   = "\" ( "\" / DQUOTE / %x6E / %x72 / %x74 / unicode-escape )
 unicode-escape = %x75 4HEXDIG
 ```
 
@@ -524,6 +524,7 @@ For an object appearing as a list item:
     - All other fields of the same object MUST appear at depth +1 under the hyphen line, in encounter order, using normal object field rules (Section 8).
     - Encoders MUST NOT emit tabular rows at depth +1 or sibling fields at the same depth as rows when the first field is a tabular array.
   - For all other cases (first field is not a tabular array), encoders SHOULD place the first field on the hyphen line. A bare hyphen on its own line is used only for empty list-item objects.
+  - Empty arrays in field positions (including list-item object fields) use the canonical `key: []` form per §9.1.
 - Decoding (normative):
   - When a decoder encounters a list-item line of the form `- key[N<delim?>]{fields}:` at depth d, it MUST treat this as the start of a tabular array field named key in the list-item object.
   - Lines at depth d+2 that conform to tabular row syntax (Section 9.3) are rows of that tabular array.
@@ -800,7 +801,7 @@ Recommended error messages:
   - Strings with colon, the relevant delimiter (document or active), hyphen marker cases ("-" or strings starting with "-"), control characters, or brackets/braces MUST be quoted.
 - Strict-mode checks (Section 14) detect malformed strings, truncation, or injected rows/items via length and width mismatches.
 - Encoders SHOULD avoid excessive memory on large inputs; implement streaming/tabular row emission where feasible.
-- Control characters in quoted strings (`\uXXXX`, §7.1) round-trip verbatim per §17.1; encoders MUST NOT strip them during normalization. Recipients that render decoded values into terminals, logs, or markup are responsible for downstream escaping; TOON is a transport format, not a sanitization boundary.
+- Control characters in quoted strings (`\uXXXX`, §7.1) are preserved as data values; encoders MUST NOT strip them during normalization. Recipients that render decoded values into terminals, logs, or markup are responsible for downstream escaping; TOON is a transport format, not a sanitization boundary.
 - Unicode:
   - Encoders SHOULD avoid altering Unicode beyond required escaping; decoders SHOULD accept valid UTF-8 in quoted strings/keys (with the escape repertoire defined in §7.1).
 
@@ -1206,6 +1207,7 @@ These sketches illustrate structure and common decoding helpers. They are inform
 ### B.5 Object and List Item Parsing
 
 - Key-value line: parse a key up to the first colon; missing colon → MUST error. The remainder of the line is the primitive value (if present).
+  - If the remainder is exactly `[]` → empty array (§9.1).
 - Nested object: "key:" with nothing after colon opens a nested object. If this is:
   - A field inside a regular object: nested fields are at depth +1 relative to that line.
   - The first field on a list-item hyphen line: nested fields at depth +2 relative to the hyphen line; subsequent fields at +1.
@@ -1255,9 +1257,9 @@ Note: Host-type normalization tests (e.g., BigInt, Date, Set, Map) are language-
 
 This appendix summarizes major changes between spec versions. For the complete changelog, see [`CHANGELOG.md`](./CHANGELOG.md) in the specification repository.
 
-### v3.1 (YYYY-MM-DD)
+### v3.1 (2026-05-18)
 
-- Added `\uXXXX` Unicode escape (§7.1) for control characters and arbitrary code points in quoted strings and keys.
+- Added `\uXXXX` Unicode escape (§7.1) for control characters and BMP code points in quoted strings and keys.
 - Canonical encoding of empty object-field arrays as `key: []` (§9.1); legacy `key[0]:` remains accepted by decoders.
 - Added security note on control-character round-tripping and downstream sanitization responsibility (§15).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,9 +2,9 @@
 
 ## Token-Oriented Object Notation
 
-**Version:** 3.0
+**Version:** 3.1
 
-**Date:** 2025-11-24
+**Date:** YYYY-MM-DD
 
 **Status:** Working Draft
 
@@ -20,7 +20,7 @@ Token-Oriented Object Notation (TOON) is a line-oriented, indentation-based text
 
 ## Status of This Document
 
-This document is a Working Draft v3.0 and may be updated, replaced, or obsoleted. Implementers should monitor the canonical repository at https://github.com/toon-format/spec for changes.
+This document is a Working Draft v3.1 and may be updated, replaced, or obsoleted. Implementers should monitor the canonical repository at https://github.com/toon-format/spec for changes.
 
 This specification is stable for implementation but not yet finalized. Breaking changes may occur in future major versions.
 
@@ -279,6 +279,7 @@ TOON is a deterministic, line-oriented, indentation-based notation.
     - Otherwise: expanded list items: key[N<delim?>]: with "- …" items (see Sections 9.4 and 10).
 - Root form discovery:
   - If the first non-empty depth-0 line is a valid root array header per Section 6 (must include a colon), decode a root array.
+  - Else if the document has exactly one non-empty line and it is the literal token `[]`, decode an empty root array (§9.1).
   - Else if the document has exactly one non-empty line and it is neither a valid array header nor a key-value line (quoted or unquoted key), decode a single primitive (examples: `hello`, `42`, `true`).
   - Otherwise, decode an object.
   - An empty document (no non-empty lines after ignoring trailing newline(s) and ignorable blank lines) decodes to an empty object `{}`.
@@ -371,7 +372,7 @@ In quoted strings and keys, the following characters MUST be escaped:
 - U+000D carriage return → "\\r"
 - U+0009 tab → "\\t"
 
-Control characters in the range U+0000 through U+001F that are not U+000A, U+000D, or U+0009 MUST be encoded using the `\uXXXX` form, where `XXXX` is exactly four hexadecimal digits. Encoders SHOULD emit lowercase hexadecimal digits. Encoders MAY use `\uXXXX` for any other Unicode code point but SHOULD prefer literal UTF-8 for printable characters.
+Control characters in the range U+0000 through U+001F that are not U+000A, U+000D, or U+0009 MUST be encoded using the `\uXXXX` form, where `XXXX` is exactly four hexadecimal digits. Encoders SHOULD emit lowercase hexadecimal digits. Encoders MAY use `\uXXXX` for any other non-surrogate code point in U+0000 through U+FFFF but SHOULD prefer literal UTF-8 for printable characters.
 
 Decoders MUST accept `\uXXXX` (case-insensitive hex digits) in quoted strings and quoted keys, converting the four digits to the corresponding Unicode code point. Decoders MUST reject `\u` followed by fewer than four hex digits, MUST reject lone surrogate code points U+D800–U+DFFF decoded from `\uXXXX`, and MUST reject any other escape sequence or unterminated strings.
 
@@ -398,7 +399,7 @@ A string value MUST be quoted if any of the following is true:
   - Or matches /^0\d+$/ (leading-zero decimals such as "05").
 - It contains a colon (:), double quote ("), or backslash (\\).
 - It contains brackets or braces ([, ], {, }).
-- It contains control characters: newline, carriage return, or tab.
+- It contains control characters in U+0000 through U+001F.
 - It contains the relevant delimiter (see §11 for complete delimiter rules):
   - For inline array values and tabular row cells: the active delimiter from the nearest array header.
   - For object field values (key: value): the document delimiter, even when the object is within an array's scope.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -56,7 +56,7 @@ Non-breaking changes (MINOR version bump) include:
 - Adding new SHOULD or MAY recommendations.
 - Expanding the specification to cover previously undefined behavior (if done in a backward-compatible way).
 - Adding new test cases that existing conformant implementations already pass.
-- Adding a normative decoder requirement that broadens accepted input without invalidating output from prior conformant encoders.
+- Adding a normative decoder requirement that broadens accepted input, compatible with existing encoder output.
 
 ### Documentation Improvements
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -56,6 +56,7 @@ Non-breaking changes (MINOR version bump) include:
 - Adding new SHOULD or MAY recommendations.
 - Expanding the specification to cover previously undefined behavior (if done in a backward-compatible way).
 - Adding new test cases that existing conformant implementations already pass.
+- Adding a normative decoder requirement that broadens accepted input without invalidating output from prior conformant encoders.
 
 ### Documentation Improvements
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ Complete, valid TOON files demonstrating core features:
 
 - [`valid/primitive-arrays.toon`](valid/primitive-arrays.toon) - Inline primitive arrays
   - Demonstrates compact inline format `[N]: item1,item2,item3`
-  - Shows empty arrays `[0]:`
+  - Shows empty arrays `[]`
   - Multiple arrays in one document
   - Spec: §9.1 Primitive Arrays
 

--- a/examples/valid/primitive-arrays.toon
+++ b/examples/valid/primitive-arrays.toon
@@ -1,3 +1,3 @@
 tags[3]: admin,ops,dev
 numbers[5]: 1,2,3,4,5
-empty[0]:
+empty: []

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toon-format/spec",
   "type": "module",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "packageManager": "pnpm@10.30.1",
   "description": "Official specification for Token-Oriented Object Notation (TOON)",
   "author": "Johann Schopplich <hello@johannschopplich.com>",

--- a/tests/fixtures/decode/arrays-nested.json
+++ b/tests/fixtures/decode/arrays-nested.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "3.1",
   "category": "decode",
   "description": "Nested and mixed array decoding - list format, arrays of arrays, root arrays, mixed types",
   "tests": [
@@ -169,6 +169,12 @@
     {
       "name": "parses empty root-level array",
       "input": "[0]:",
+      "expected": [],
+      "specSection": "9.1"
+    },
+    {
+      "name": "decodes canonical empty root array",
+      "input": "[]",
       "expected": [],
       "specSection": "9.1"
     },

--- a/tests/fixtures/decode/arrays-primitive.json
+++ b/tests/fixtures/decode/arrays-primitive.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "3.1",
   "category": "decode",
   "description": "Primitive array decoding - inline arrays of strings, numbers, booleans, quoted strings",
   "tests": [
@@ -118,6 +118,30 @@
     {
       "name": "parses quoted empty string key with empty array",
       "input": "\"\"[0]:",
+      "expected": {
+        "": []
+      },
+      "specSection": "9.1"
+    },
+    {
+      "name": "decodes canonical empty array key: []",
+      "input": "items: []",
+      "expected": {
+        "items": []
+      },
+      "specSection": "9.1"
+    },
+    {
+      "name": "decodes canonical empty array with quoted key",
+      "input": "\"x-custom\": []",
+      "expected": {
+        "x-custom": []
+      },
+      "specSection": "9.1"
+    },
+    {
+      "name": "decodes canonical empty array with empty-string key",
+      "input": "\"\": []",
       "expected": {
         "": []
       },

--- a/tests/fixtures/decode/objects.json
+++ b/tests/fixtures/decode/objects.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "3.1",
   "category": "decode",
   "description": "Object decoding - simple objects, nested objects, key parsing, quoted values",
   "tests": [
@@ -27,6 +27,14 @@
       "input": "user:",
       "expected": {
         "user": {}
+      },
+      "specSection": "8"
+    },
+    {
+      "name": "bare key: with no children decodes as empty object, not array",
+      "input": "matches:",
+      "expected": {
+        "matches": {}
       },
       "specSection": "8"
     },

--- a/tests/fixtures/decode/primitives.json
+++ b/tests/fixtures/decode/primitives.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "3.1",
   "category": "decode",
   "description": "Primitive value decoding - strings, numbers, booleans, null, unescaping",
   "tests": [
@@ -49,6 +49,18 @@
       "name": "parses quoted string with escaped quotes",
       "input": "\"say \\\"hello\\\"\"",
       "expected": "say \"hello\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "decodes \\uXXXX escape (U+0004)",
+      "input": "val: \"a\\u0004b\"",
+      "expected": { "val": "a\u0004b" },
+      "specSection": "7.1"
+    },
+    {
+      "name": "decodes \\uXXXX with mixed-case hex digits",
+      "input": "val: \"a\\u00Abb\"",
+      "expected": { "val": "a«b" },
       "specSection": "7.1"
     },
     {

--- a/tests/fixtures/decode/validation-errors.json
+++ b/tests/fixtures/decode/validation-errors.json
@@ -39,7 +39,7 @@
       "specSection": "14.2"
     },
     {
-      "name": "rejects truncated unicode escape \\u00",
+      "name": "rejects truncated unicode escape \\u00b",
       "input": "val: \"a\\u00b\"",
       "expected": null,
       "shouldError": true,

--- a/tests/fixtures/decode/validation-errors.json
+++ b/tests/fixtures/decode/validation-errors.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "3.1",
   "category": "decode",
   "description": "Validation errors - length mismatches, invalid escapes, syntax errors, delimiter mismatches",
   "tests": [
@@ -37,6 +37,20 @@
       "expected": null,
       "shouldError": true,
       "specSection": "14.2"
+    },
+    {
+      "name": "rejects truncated unicode escape \\u00",
+      "input": "val: \"a\\u00b\"",
+      "expected": null,
+      "shouldError": true,
+      "specSection": "7.1"
+    },
+    {
+      "name": "rejects lone surrogate code point \\uD800",
+      "input": "val: \"a\\uD800b\"",
+      "expected": null,
+      "shouldError": true,
+      "specSection": "7.1"
     },
     {
       "name": "throws on unterminated string",

--- a/tests/fixtures/encode/arrays-nested.json
+++ b/tests/fixtures/encode/arrays-nested.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "3.1",
   "category": "encode",
   "description": "Nested and mixed array encoding - arrays of arrays, mixed type arrays, root arrays",
   "tests": [
@@ -68,7 +68,7 @@
     {
       "name": "encodes empty root-level array",
       "input": [],
-      "expected": "[0]:",
+      "expected": "[]",
       "specSection": "9.1"
     },
     {
@@ -82,7 +82,7 @@
           "prefs": []
         }
       },
-      "expected": "user:\n  id: 123\n  name: Ada\n  tags[2]: reading,gaming\n  active: true\n  prefs[0]:",
+      "expected": "user:\n  id: 123\n  name: Ada\n  tags[2]: reading,gaming\n  active: true\n  prefs: []",
       "specSection": "8"
     },
     {

--- a/tests/fixtures/encode/arrays-objects.json
+++ b/tests/fixtures/encode/arrays-objects.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0",
+  "version": "3.1",
   "category": "encode",
   "description": "Arrays of objects encoding - list format for non-uniform objects and complex structures",
   "tests": [
@@ -94,7 +94,7 @@
           { "name": "Ada", "data": [] }
         ]
       },
-      "expected": "items[1]:\n  - name: Ada\n    data[0]:",
+      "expected": "items[1]:\n  - name: Ada\n    data: []",
       "specSection": "10"
     },
     {
@@ -120,7 +120,7 @@
       "input": {
         "items": [{ "data": [], "name": "x" }]
       },
-      "expected": "items[1]:\n  - data[0]:\n    name: x",
+      "expected": "items[1]:\n  - data: []\n    name: x",
       "specSection": "10"
     },
     {

--- a/tests/fixtures/encode/arrays-primitive.json
+++ b/tests/fixtures/encode/arrays-primitive.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "3.1",
   "category": "encode",
   "description": "Primitive array encoding - inline arrays of strings, numbers, booleans",
   "tests": [
@@ -32,7 +32,7 @@
       "input": {
         "items": []
       },
-      "expected": "items[0]:",
+      "expected": "items: []",
       "specSection": "9.1"
     },
     {
@@ -48,7 +48,7 @@
       "input": {
         "": []
       },
-      "expected": "\"\"[0]:",
+      "expected": "\"\": []",
       "specSection": "9.1"
     },
     {

--- a/tests/fixtures/encode/primitives.json
+++ b/tests/fixtures/encode/primitives.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4",
+  "version": "3.1",
   "category": "encode",
   "description": "Primitive value encoding - strings, numbers, booleans, null",
   "tests": [
@@ -81,6 +81,12 @@
       "name": "escapes carriage return in string",
       "input": "return\rcarriage",
       "expected": "\"return\\rcarriage\"",
+      "specSection": "7.1"
+    },
+    {
+      "name": "encodes string with U+0004 control character via \\uXXXX",
+      "input": { "val": "a\u0004b" },
+      "expected": "val: \"a\\u0004b\"",
       "specSection": "7.1"
     },
     {


### PR DESCRIPTION
## Summary

- **`\uXXXX` Unicode escape** (§7.1, closes #39) — closes the JSON representability gap for control characters U+0000–U+001F not covered by `\n`, `\r`, `\t`. Decoders accept either case in hex digits; encoders SHOULD emit lowercase. Lone surrogates U+D800–U+DFFF rejected; supplementary code points use literal UTF-8.
- **Canonical empty-array encoding `key: []`** (§9.1, closes #50) — encoders SHOULD emit `key: []`; decoders MUST accept both canonical and legacy `key[0]:`. Bare `key:` remains reserved for empty/nested objects (§8). Inner empty arrays in arrays-of-arrays (§9.2) retain `- [0]:` for parse clarity.
- **§15 control-character smuggling note** (rides #39) — pins encoders MUST NOT strip control characters during normalization; round-trip fidelity preserved per §17.1; downstream sanitization is recipient responsibility.

VERSIONING.md gains one bullet clarifying that decoder requirements broadening accepted input without invalidating prior encoder output are MINOR.

Cross-reference sweeps: §4, §13.1, §13.2, §13.3, §14.1, §15:802, §19, §20, Appendix A:1058, Appendix B.4, Appendix D, CHANGELOG.md.

Three commits, one per concern, surgical scope each:
- `bad304c` feat(spec): add \uXXXX unicode escape (§7.1)
- `6cab9b9` feat(spec): canonicalize empty array encoding as \`key: []\` (§9.1)
- `1e6fe45` feat(spec): add §15 control-character smuggling note

Each was produced by a parallel Opus + GPT-5.5 edit run against a shared brief; commits represent the diffed-and-merged best-of-both result.

## Test plan

- [ ] Reference impl (toon-format/toon) updated to emit/accept new forms and ships with green CI
- [ ] Five new `\uXXXX` fixtures pass (encode U+0004; decode U+0004; decode mixed-case hex; reject truncated `\u00`; reject lone surrogate `\uD800`)
- [ ] Five new empty-array fixtures pass (canonical `key: []`, quoted key, empty-string key, root `[]`, bare-`key:` → empty object regression)
- [ ] Eight existing legacy `key[0]:` decode fixtures continue to pass (backward compatibility)
- [ ] Encoder fixtures for `arrays-primitive`, `arrays-nested`, `arrays-objects` produce canonical `key: []` shape
- [ ] Replace `YYYY-MM-DD` placeholders in CHANGELOG.md and SPEC.md Appendix D on release day
- [ ] README badge/test count refreshed if applicable