### PR TITLE
test: add ambiguous leading-plus decode fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - §7.1 ABNF `unescaped-char`: supplementary scalars (`%x10000-10FFFF`) included explicitly.
 - §13: option names and value tokens are concept handles; implementations MAY use language-idiomatic spellings or types.
 - Appendix F.5: informative Java mapping section.
+- Tests: decode fixtures for ambiguous leading-plus tokens, matching reference behavior.
 
 ### Changed
 

--- a/tests/fixtures/decode/numbers.json
+++ b/tests/fixtures/decode/numbers.json
@@ -90,6 +90,25 @@
       "note": "Exponent +00 results in the integer 5"
     },
     {
+      "name": "treats leading plus integer as string",
+      "input": "value: +1",
+      "expected": {
+        "value": "+1"
+      },
+      "specSection": "4",
+      "note": "The spec is silent on leading-plus tokens; the reference implementation treats them as strings"
+    },
+    {
+      "name": "treats leading plus numeric-looking tokens as strings",
+      "input": "values[3]: +1,+1.5,+1e2\nexponent: 1e+2",
+      "expected": {
+        "values": ["+1", "+1.5", "+1e2"],
+        "exponent": 100
+      },
+      "specSection": "4",
+      "note": "Reference behavior: exponent plus signs are numeric, but leading-plus tokens remain strings"
+    },
+    {
       "name": "parses zero with exponent as number",
       "input": "value: 0e1",
       "expected": {


### PR DESCRIPTION
## Summary

- Add decode fixtures that keep leading-plus numeric-looking tokens as strings.
- Cover both an object value and inline array values, while confirming `1e+2` still decodes as a number.
- Record the fixture addition in the changelog as ambiguous leading-plus coverage matching reference behavior.

## Rationale

The current spec says decoders accept decimal and exponent forms, and it explicitly calls out forbidden leading zeros, but it does not explicitly say what happens to leading-plus tokens like `+1`. That leaves room for implementations to accidentally inherit host parser behavior, since some host numeric parsers accept `+1`.

The current reference implementation treats leading-plus tokens as strings. Its numeric literal pattern allows an optional leading `-`, but not `+`, and `parsePrimitiveToken` falls back to unquoted string behavior when the numeric check fails:

- [`literal-utils.ts`](https://github.com/toon-format/toon/blob/a956757de07f413a6633ea4e2dfd150ddac057d4/packages/toon/src/shared/literal-utils.ts#L3-L25)
- [`parser.ts`](https://github.com/toon-format/toon/blob/a956757de07f413a6633ea4e2dfd150ddac057d4/packages/toon/src/decode/parser.ts#L248-L278)

I also verified the reference implementation source directly:

```json
{"value":"+1","values":["+1","+1.5","+1e2"],"exponent":100}
```

## Validation

- `node --experimental-strip-types --input-type=module -e "import { decode } from './packages/toon/src/index.ts'; ..."` in `toon-format/toon`
- `node --input-type=module -e "...JSON.parse..."`
- `npx --yes ajv-cli validate -s tests/fixtures.schema.json -d "tests/fixtures/**/*.json"`
- `npm run lint`
- `zig build test` in `LatentEvals/toon-zig` against the implementation that motivated this fixture coverage
