### PR TITLE
test: add nested empty-object list item fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - §7.1 ABNF `unescaped-char`: supplementary scalars (`%x10000-10FFFF`) included explicitly.
 - §13: option names and value tokens are concept handles; implementations MAY use language-idiomatic spellings or types.
 - Appendix F.5: informative Java mapping section.
+- Test fixtures: nested expanded arrays containing empty object list items, confirming recursive bare-hyphen encoding/decoding per §9.4/§10.
 
 ### Changed
 

--- a/tests/fixtures/decode/arrays-nested.json
+++ b/tests/fixtures/decode/arrays-nested.json
@@ -161,6 +161,16 @@
       "specSection": "9.4"
     },
     {
+      "name": "parses nested arrays with empty object list items",
+      "input": "items[2]:\n  - [1]:\n    -\n  - [2]:\n    - x\n    -",
+      "expected": {
+        "items": [[{}], ["x", {}]]
+      },
+      "specSection": "9.4",
+      "minSpecVersion": "3.2",
+      "note": "The bare hyphen marker for an empty object list item applies recursively inside nested expanded arrays"
+    },
+    {
       "name": "parses root-level array of arrays",
       "input": "[2]:\n  - [2]: 1,2\n  - [0]:",
       "expected": [[1, 2], []],

--- a/tests/fixtures/encode/arrays-nested.json
+++ b/tests/fixtures/encode/arrays-nested.json
@@ -60,6 +60,16 @@
       "specSection": "9.4"
     },
     {
+      "name": "encodes nested arrays with empty object list items as bare hyphen",
+      "input": {
+        "items": [[{}], ["x", {}]]
+      },
+      "expected": "items[2]:\n  - [1]:\n    -\n  - [2]:\n    - x\n    -",
+      "specSection": "9.4",
+      "minSpecVersion": "3.2",
+      "note": "Nested non-primitive arrays use expanded list form per §9.4; empty object list items inside them still encode as a bare hyphen per §10, with no trailing space per §12"
+    },
+    {
       "name": "encodes root-level arrays of arrays",
       "input": [[1, 2], []],
       "expected": "[2]:\n  - [2]: 1,2\n  - [0]:",


### PR DESCRIPTION
## Summary

- Add encode/decode fixtures for nested expanded arrays containing empty object list items.
- Confirm recursive empty-object list items encode as a bare `-` marker with no trailing space.
- Record the fixture addition in the changelog.

## Rationale

The spec already defines this behavior:

- §9.4 says expanded list items may use a bare `-` marker for empty object list items.
- §10 says an empty object list item is a single `-` at the list-item indentation level.
- §12 says encoders MUST NOT emit trailing spaces.

The reference implementation follows that rule recursively. `encodeObjectAsListItemLines` emits `LIST_ITEM_MARKER` for empty objects, where `LIST_ITEM_MARKER` is `"-"` and `LIST_ITEM_PREFIX` is `"- "` for non-empty list items:

- https://github.com/toon-format/toon/blob/main/packages/toon/src/encode/encoders.ts#L287-L293
- https://github.com/toon-format/toon/blob/main/packages/toon/src/constants.ts#L3-L4

I verified the current reference implementation directly:

```toon
items[2]:
  - [1]:
    -
  - [2]:
    - x
    -
```

decodes back to:

```json
{"items":[[{}],["x",{}]]}
```

## Coverage gap

The current fixtures cover empty object list items at the outer list level, for example:

```toon
items[3]:
  - first
  - second
  -
```

They also cover arrays of empty objects as outer list items. What was missing is the recursive nested-array case:

```json
{"items":[[{}],["x",{}]]}
```

That gap lets an encoder special-case empty objects in top-level expanded arrays while still emitting `- ` with a trailing space for empty objects inside nested expanded arrays. This PR adds encode and decode coverage for that recursive case.

## Validation

- `node --input-type=module -e "JSON.parse(...)"` for modified fixture JSON
- `npx --yes ajv-cli validate -s tests/fixtures.schema.json -d "tests/fixtures/**/*.json"`
- `npm run lint`
- `node --experimental-strip-types --input-type=module -e "import { encode, decode } from './packages/toon/src/index.ts'; ..."` in `toon-format/toon`
- `zig build test --summary all` in `LatentEvals/toon-zig`
