### PR TITLE
docs(README): link to TOON Validation Guide (community)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The TOON specification uses MAJOR.MINOR versioning. See [VERSIONING.md](./VERSIO
 - **Changelog:** [CHANGELOG.md](./CHANGELOG.md) - Version history and changes
 - **Reference Implementation:** [github.com/toon-format/toon](https://github.com/toon-format/toon) - TypeScript/JavaScript implementation
 - **Benchmarks:** [Reference repo benchmarks/](https://github.com/toon-format/toon/tree/main/benchmarks) - Token efficiency measurements and accuracy retrieval tests
+- **Validation Guide:** [github.com/apardawala/toon-validation-guide](https://github.com/apardawala/toon-validation-guide) - JSON Schema 2020-12 patterns for decoded TOON (community-maintained)
 
 ## License
 


### PR DESCRIPTION
## What

Adds one Resources link to https://github.com/apardawala/toon-validation-guide — a non-normative, community-maintained companion documenting how to validate decoded TOON against JSON Schema 2020-12.

## Why

Schema validation is a common downstream need for any serialization format, and TOON's value model maps cleanly onto JSON Schema 2020-12. The guide documents the decode-then-validate pattern with runnable TypeScript (Ajv 8) and Rust (`jsonschema` 0.46) examples sharing one set of TOON + schema fixtures, plus empirical coverage of the integer/number distinction — the one place where TOON's single numeric type interacts with JSON Schema's split — and round-trip tests for JSON Schema documents through TOON.

## What this is not

Pinned to TOON v3.x and JSON Schema 2020-12; tracks the spec, doesn't extend it. The "community-maintained" qualifier is in the link text on purpose.